### PR TITLE
Disable display_errors in php.ini

### DIFF
--- a/docker/php.ini
+++ b/docker/php.ini
@@ -1,1 +1,2 @@
 date.timezone = "UTC"
+display_errors = 0


### PR DESCRIPTION
We saw one case of errors appearing in JSON responses breaking their parsing[1]. This commit should disable displaying (in the response) but not disable all
reporting[2].

[1] https://github.com/magnusmanske/quickstatements/pull/58
[2] https://stackoverflow.com/a/21699794