### PR TITLE
update magnustools for new mw routing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "require": {
         "addwiki/mediawiki-api": "~2.0",
-        "wbstack/magnustools": "dev-main#855a8bb2e24433c2cf582c0dcbd504bf902f1ad1"
+        "wbstack/magnustools": "dev-main#TBD"
     },
     "scripts": {
         "post-install-cmd": [

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "require": {
         "addwiki/mediawiki-api": "~2.0",
-        "wbstack/magnustools": "dev-main#TBD"
+        "wbstack/magnustools": "de/refactor-routing#c85e981827f4976ace338dca325a6bc27396146a"
     },
     "scripts": {
         "post-install-cmd": [

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "require": {
         "addwiki/mediawiki-api": "~2.0",
-        "wbstack/magnustools": "de/refactor-routing#c85e981827f4976ace338dca325a6bc27396146a"
+        "wbstack/magnustools": "dev-de/refactor-routing#c85e981827f4976ace338dca325a6bc27396146a"
     },
     "scripts": {
         "post-install-cmd": [

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "require": {
         "addwiki/mediawiki-api": "~2.0",
-        "wbstack/magnustools": "dev-de/refactor-routing#c85e981827f4976ace338dca325a6bc27396146a"
+        "wbstack/magnustools": "dev-de/refactor-routing#a70a8472e59027912fcec73c987d4ec8358eec8e"
     },
     "scripts": {
         "post-install-cmd": [

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "require": {
         "addwiki/mediawiki-api": "~2.0",
-        "wbstack/magnustools": "dev-de/refactor-routing#a70a8472e59027912fcec73c987d4ec8358eec8e"
+        "wbstack/magnustools": "dev-main#02267937eec783642d30ce987c53a99e285f4676"
     },
     "scripts": {
         "post-install-cmd": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6cec40bbc8ee253be7d447dc032a3f8d",
+    "content-hash": "d8457eb564dc1a87d6e5e41b78510919",
     "packages": [
         {
             "name": "abraham/twitteroauth",
@@ -1007,16 +1007,16 @@
         },
         {
             "name": "wbstack/magnustools",
-            "version": "dev-main",
+            "version": "dev-de/refactor-routing",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wbstack/magnustools.git",
-                "reference": "855a8bb2e24433c2cf582c0dcbd504bf902f1ad1"
+                "reference": "c85e981827f4976ace338dca325a6bc27396146a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wbstack/magnustools/zipball/855a8bb2e24433c2cf582c0dcbd504bf902f1ad1",
-                "reference": "855a8bb2e24433c2cf582c0dcbd504bf902f1ad1",
+                "url": "https://api.github.com/repos/wbstack/magnustools/zipball/c85e981827f4976ace338dca325a6bc27396146a",
+                "reference": "c85e981827f4976ace338dca325a6bc27396146a",
                 "shasum": ""
             },
             "require": {
@@ -1028,7 +1028,6 @@
             "require-dev": {
                 "phpunit/phpunit": "^8.0"
             },
-            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
@@ -1052,7 +1051,7 @@
                 "issues": "https://bitbucket.org/magnusmanske/magnustools/issues?status=new&status=open",
                 "source": "https://bitbucket.org/magnusmanske/magnustools/"
             },
-            "time": "2025-11-04T13:40:11+00:00"
+            "time": "2025-11-17T15:27:08+00:00"
         }
     ],
     "packages-dev": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d8457eb564dc1a87d6e5e41b78510919",
+    "content-hash": "dea476170cf2b5b0b89eb2b38f22a5e1",
     "packages": [
         {
             "name": "abraham/twitteroauth",
@@ -1011,12 +1011,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/wbstack/magnustools.git",
-                "reference": "c85e981827f4976ace338dca325a6bc27396146a"
+                "reference": "a70a8472e59027912fcec73c987d4ec8358eec8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wbstack/magnustools/zipball/c85e981827f4976ace338dca325a6bc27396146a",
-                "reference": "c85e981827f4976ace338dca325a6bc27396146a",
+                "url": "https://api.github.com/repos/wbstack/magnustools/zipball/a70a8472e59027912fcec73c987d4ec8358eec8e",
+                "reference": "a70a8472e59027912fcec73c987d4ec8358eec8e",
                 "shasum": ""
             },
             "require": {
@@ -1051,7 +1051,7 @@
                 "issues": "https://bitbucket.org/magnusmanske/magnustools/issues?status=new&status=open",
                 "source": "https://bitbucket.org/magnusmanske/magnustools/"
             },
-            "time": "2025-11-17T15:27:08+00:00"
+            "time": "2025-11-18T15:49:00+00:00"
         }
     ],
     "packages-dev": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dea476170cf2b5b0b89eb2b38f22a5e1",
+    "content-hash": "18a01abc664c2a7f089b42b168042d1b",
     "packages": [
         {
             "name": "abraham/twitteroauth",
@@ -1007,16 +1007,16 @@
         },
         {
             "name": "wbstack/magnustools",
-            "version": "dev-de/refactor-routing",
+            "version": "dev-main",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wbstack/magnustools.git",
-                "reference": "a70a8472e59027912fcec73c987d4ec8358eec8e"
+                "reference": "02267937eec783642d30ce987c53a99e285f4676"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wbstack/magnustools/zipball/a70a8472e59027912fcec73c987d4ec8358eec8e",
-                "reference": "a70a8472e59027912fcec73c987d4ec8358eec8e",
+                "url": "https://api.github.com/repos/wbstack/magnustools/zipball/02267937eec783642d30ce987c53a99e285f4676",
+                "reference": "02267937eec783642d30ce987c53a99e285f4676",
                 "shasum": ""
             },
             "require": {
@@ -1028,6 +1028,7 @@
             "require-dev": {
                 "phpunit/phpunit": "^8.0"
             },
+            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
@@ -1051,7 +1052,7 @@
                 "issues": "https://bitbucket.org/magnusmanske/magnustools/issues?status=new&status=open",
                 "source": "https://bitbucket.org/magnusmanske/magnustools/"
             },
-            "time": "2025-11-18T15:49:00+00:00"
+            "time": "2025-11-20T09:15:14+00:00"
         }
     ],
     "packages-dev": [],


### PR DESCRIPTION
Update magnustools to include https://github.com/wbstack/magnustools/pull/21

TODO:
- [x] actually insert the right commit hash in composer.json
- [x] update composer.lock

Bug: T409531

https://phabricator.wikimedia.org/T409531

